### PR TITLE
Switch from deprecated tbb::atomic to std::atomic

### DIFF
--- a/computation/progmcrt_merge/ProgMcrtMergeClockDeltaDriver.h
+++ b/computation/progmcrt_merge/ProgMcrtMergeClockDeltaDriver.h
@@ -8,12 +8,11 @@
 #include <mcrt_dataio/share/sock/SockServer.h>
 #include <mcrt_dataio/share/sock/SockServerConnection.h>
 
-#include <tbb/atomic.h>
-
 #include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <atomic>
 
 namespace mcrt_computation {
 
@@ -52,8 +51,8 @@ private:
 
     std::thread mServerThread;
     std::thread mWorkerThread;  // single worker
-    tbb::atomic<ThreadState> mServerThreadState;
-    tbb::atomic<ThreadState> mWorkerThreadState;
+    std::atomic<ThreadState> mServerThreadState;
+    std::atomic<ThreadState> mWorkerThreadState;
     bool mThreadShutdown;
 
     mutable std::mutex mMutex;

--- a/lib/engine/mcrt/RenderContextDriver.h
+++ b/lib/engine/mcrt/RenderContextDriver.h
@@ -27,8 +27,6 @@
 #include <scene_rdl2/common/grid_util/Parser.h>
 #include <scene_rdl2/common/math/Viewport.h>
 
-#include <tbb/atomic.h>
-
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -345,8 +343,8 @@ private:
     //
     int mDriverId;
     std::thread mThread;
-    tbb::atomic<ThreadState> mThreadState {ThreadState::INIT};
-    tbb::atomic<RunState> mRunState {RunState::WAIT};
+    std::atomic<ThreadState> mThreadState {ThreadState::INIT};
+    std::atomic<RunState> mRunState {RunState::WAIT};
     bool mThreadShutdown {false}; 
 
     mutable std::mutex mMutexBoot;


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  
Jira ticket: na
Release Notes Comment: 

Special Notes: Changes away from tbb::atomic to the std::atomic as it has been deprecated and removed in tbb 2021+

Look or Scene Setup Change: No