### PR TITLE
Add missing std includes

### DIFF
--- a/lib/engine/mcrt/McrtUpdate.h
+++ b/lib/engine/mcrt/McrtUpdate.h
@@ -9,6 +9,8 @@
 #include <message_api/messageapi_names.h>
 #include <message_api/Object.h>
 
+#include <functional>
+
 namespace mcrt_computation {
 
 class McrtUpdate


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  
Jira ticket: na
Release Notes Comment: Fix build errors due to missing std includes

Special Notes: Currently fails to build with newer compilers, need to add in the includes for some of the standard library types used.

Look or Scene Setup Change: No
